### PR TITLE
Generate forms from YAML configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/_site
+/.jekyll-cache

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,7 @@
+title: GAIDeT Declaration Generator
+markdown: kramdown
+theme: minima
+plugins:
+  - jekyll-feed
+  - jekyll-sitemap
+  - jekyll-paginate

--- a/_data/terms.yml
+++ b/_data/terms.yml
@@ -1,0 +1,57 @@
+conceptualization:
+  - label: Idea generation
+  - label: Defining the research objective
+  - label: Formulating research questions and hypotheses
+  - label: Feasibility assessment and risk evaluation
+  - label: Preliminary hypothesis testing
+
+review:
+  - label: Literature search and systematization
+  - label: Writing the literature review
+  - label: Analysis of market trends and/or patent environment
+  - label:  Evaluation of the novelty of the research and identification of gaps
+
+methodology:
+  - label: Research design
+  - label: Development of experimental or research protocols
+  - label: Selection of research methods
+
+
+software:
+  - label: Code generation
+  - label: Code optimization
+  - label: Process automation
+  - label: Creation of algorithms for data analysis
+
+data:
+  - label: Data collection
+  - label: Validation
+  - label: Data cleaning
+  - label: Data curation and organization
+  - label: Data analysis
+  - label: Visualization
+  - label: Reproducibility testing
+    
+writing:
+  - label:Text generation
+  - label: Proofreading and editing
+  - label: Summarizing text
+  - label: Formulation of conclusions
+  - label: Adapting and adjusting emotional tone
+  - label: Translation
+  - label: Reformatting
+  - label: Preparation of press releases and outreach materials
+
+
+ethics:
+  - label: Bias analysis and potential discrimination assessment
+  - label: Ethical risk analysis
+  - label: Monitoring compliance with ethical standards
+  - label: Data confidentiality monitoring
+
+supervision:
+  - label: Quality assessment
+  - label: Trend identification
+  - label: Identification of limitations
+  - label: Recommendations
+  - label: Publication support

--- a/_data/terms.yml
+++ b/_data/terms.yml
@@ -1,57 +1,120 @@
 conceptualization:
-  - label: Idea generation
-  - label: Defining the research objective
-  - label: Formulating research questions and hypotheses
-  - label: Feasibility assessment and risk evaluation
-  - label: Preliminary hypothesis testing
+  label: Conceptulaization
+  label_uk: Концептуалізація
+  terms:
+    - label: Idea generation
+      label_uk: Генерування ідей
+    - label: Defining the research objective
+      label_uk: Визначення мети дослідження
+    - label: Formulating research questions and hypotheses
+      label_uk: Формулювання дослідницьких питань і гіпотез
+    - label: Feasibility assessment and risk evaluation
+      label_uk: Оцінювання здійсненності та ризиків
+    - label: Preliminary hypothesis testing
+      label_uk: Попереднє тестування гіпотез
 
 review:
-  - label: Literature search and systematization
-  - label: Writing the literature review
-  - label: Analysis of market trends and/or patent environment
-  - label:  Evaluation of the novelty of the research and identification of gaps
+  label: Literature Review
+  label_uk: Огляд літератури
+  terms:
+    - label: Literature search and systematization
+      label_uk: Пошук і систематизація літератури
+    - label: Writing the literature review
+      label_uk: Написання огляду літератури
+    - label: Analysis of market trends and/or patent environment
+      label_uk: Аналіз ринкових трендів та/або патентного середовища
+    - label: Evaluation of the novelty of the research and identification of gaps
+      label_uk: Оцінювання новизни дослідження та виявлення прогалин
 
 methodology:
-  - label: Research design
-  - label: Development of experimental or research protocols
-  - label: Selection of research methods
+  label: Methodology
+  label_uk: Методологія
+  terms:
+    - label: Research design
+      label_uk: Дизайн дослідження
+    - label: Development of experimental or research protocols
+      label_uk: Розроблення експериментальних або дослідницьких протоколів
+    - label: Selection of research methods
+      label_uk: Вибір методів дослідження
 
 
 software:
-  - label: Code generation
-  - label: Code optimization
-  - label: Process automation
-  - label: Creation of algorithms for data analysis
+  label: Software Development and Automation
+  label_uk: Розробка ПЗ та автоматизація
+  terms:
+    - label: Code generation
+      label_uk: Генерування коду
+    - label: Code optimization
+      label_uk: Оптимізація коду
+    - label: Process automation
+      label_uk: Автоматизація процесів
+    - label: Creation of algorithms for data analysis
+      label_uk: Створення алгоритмів для аналізу даних
 
 data:
-  - label: Data collection
-  - label: Validation
-  - label: Data cleaning
-  - label: Data curation and organization
-  - label: Data analysis
-  - label: Visualization
-  - label: Reproducibility testing
-    
-writing:
-  - label:Text generation
-  - label: Proofreading and editing
-  - label: Summarizing text
-  - label: Formulation of conclusions
-  - label: Adapting and adjusting emotional tone
-  - label: Translation
-  - label: Reformatting
-  - label: Preparation of press releases and outreach materials
+  label: Data Management
+  label_uk: Керування даними
+  terms:
+    - label: Data collection
+      label_uk: Збирання даних
+    - label: Validation
+      label_uk: Валідація
+    - label: Data cleaning
+      label_uk: Очищення даних
+    - label: Data curation and organization
+      label_uk: Курація та організація даних
+    - label: Data analysis
+      label_uk: Аналіз даних
+    - label: Visualization
+      label_uk: Візуалізація
+    - label: Reproducibility testing
+      label_uk: Перевірка відтворюваності
 
+writing:
+  label: Writing and Editing
+  label_uk: Написання й редагування
+  terms:
+    - label: Text generation
+      label_uk: Генерування тексту
+    - label: Proofreading and editing
+      label_uk: Вичитування та редагування
+    - label: Summarizing text
+      label_uk: Резюмування тексту
+    - label: Formulation of conclusions
+      label_uk: Формулювання висновків
+    - label: Adapting and adjusting emotional tone
+      label_uk: Адаптація та коригування емоційного тону
+    - label: Translation
+      label_uk: Переклад
+    - label: Reformatting
+      label_uk: Реформатування
+    - label: Preparation of press releases and outreach materials
+      label_uk: Підготовка пресрелізів та матеріалів для популяризації
 
 ethics:
-  - label: Bias analysis and potential discrimination assessment
-  - label: Ethical risk analysis
-  - label: Monitoring compliance with ethical standards
-  - label: Data confidentiality monitoring
+  label: Ethics Review
+  label_uk: Етичний аналіз
+  terms:
+    - label: Bias analysis and potential discrimination assessment
+      label_uk: Аналіз упередженості та потенційної дискримінації
+    - label: Ethical risk analysis
+      label_uk: Аналіз етичних ризиків
+    - label: Monitoring compliance with ethical standards
+      label_uk: Моніторинг дотримання етичних стандартів
+    - label: Data confidentiality monitoring
+      label_uk: Моніторинг конфіденційності даних
 
 supervision:
-  - label: Quality assessment
-  - label: Trend identification
-  - label: Identification of limitations
-  - label: Recommendations
-  - label: Publication support
+  label: Supervision
+  label_uk: Нагляд і керівництво
+  terms:
+    - label: Quality assessment
+      label_uk: Оцінювання якості
+    - label: Trend identification
+      label_uk: Виявлення трендів
+    - label: Identification of limitations
+      label_uk: Визначення обмежень
+    - label: Recommendations
+      label_uk: Рекомендації
+    - label: Publication support
+      label_uk: Підтримка публікації

--- a/index-uk.html
+++ b/index-uk.html
@@ -89,91 +89,75 @@
     <h2>3. Оберіть делеговані завдання (за таксономією GAIDeT)</h2>
 
     <details open>
-      <summary>Концептуалізація</summary>
-      <div class="task-group">
-        <label><input type="checkbox" value="Генерування ідей"> Генерування ідей</label>
-        <label><input type="checkbox" value="Визначення мети дослідження"> Визначення мети дослідження</label>
-        <label><input type="checkbox" value="Формулювання дослідницьких питань і гіпотез"> Формулювання дослідницьких питань і гіпотез</label>
-        <label><input type="checkbox" value="Оцінювання здійсненності та ризиків"> Оцінювання здійсненності та ризиків</label>
-        <label><input type="checkbox" value="Попереднє тестування гіпотез"> Попереднє тестування гіпотез</label>
-      </div>
+        <summary>{{ site.data.terms.conceptualization.label_uk }}</summary>
+        <div class="task-group">
+            {%- for element in site.data.terms.conceptualization.terms %}
+            <label><input type="checkbox" value="{{ element.label_uk }}">{{ element.label_uk }}</label>
+            {%- endfor %}
+        </div>
     </details>
 
     <details>
-      <summary>Огляд літератури</summary>
-      <div class="task-group">
-        <label><input type="checkbox" value="Пошук і систематизація літератури"> Пошук і систематизація літератури</label>
-        <label><input type="checkbox" value="Написання огляду літератури"> Написання огляду літератури</label>
-        <label><input type="checkbox" value="Аналіз ринкових трендів та/або патентного середовища"> Аналіз ринкових трендів та/або патентного середовища</label>
-        <label><input type="checkbox" value="Оцінювання новизни дослідження та виявлення прогалин"> Оцінювання новизни дослідження та виявлення прогалин</label>
-      </div>
+        <summary>{{ site.data.terms.review.label_uk }}</summary>
+        <div class="task-group">
+            {%- for element in site.data.terms.review.terms %}
+            <label><input type="checkbox" value="{{ element.label_uk }}">{{ element.label_uk }}</label>
+            {%- endfor %}
+        </div>
     </details>
 
     <details>
-      <summary>Методологія</summary>
-      <div class="task-group">
-        <label><input type="checkbox" value="Дизайн дослідження"> Дизайн дослідження</label>
-        <label><input type="checkbox" value="Розроблення експериментальних або дослідницьких протоколів"> Розроблення експериментальних або дослідницьких протоколів</label>
-        <label><input type="checkbox" value="Вибір методів дослідження"> Вибір методів дослідження</label>
-      </div>
+        <summary>{{ site.data.terms.methodology.label_uk }}</summary>
+        <div class="task-group">
+            {%- for element in site.data.terms.methodology.terms %}
+            <label><input type="checkbox" value="{{ element.label_uk }}">{{ element.label_uk }}</label>
+            {%- endfor %}
+        </div>
     </details>
 
     <details>
-      <summary>Розробка ПЗ та автоматизація</summary>
-      <div class="task-group">
-        <label><input type="checkbox" value="Генерування коду"> Генерування коду</label>
-        <label><input type="checkbox" value="Оптимізація коду"> Оптимізація коду</label>
-        <label><input type="checkbox" value="Автоматизація процесів"> Автоматизація процесів</label>
-        <label><input type="checkbox" value="Створення алгоритмів для аналізу даних"> Створення алгоритмів для аналізу даних</label>
-      </div>
+        <summary>{{ site.data.terms.software.label_uk }}</summary>
+        <div class="task-group">
+            {%- for element in site.data.terms.software.terms %}
+            <label><input type="checkbox" value="{{ element.label_uk }}">{{ element.label_uk }}</label>
+            {%- endfor %}
+        </div>
     </details>
 
     <details>
-      <summary>Керування даними</summary>
-      <div class="task-group">
-        <label><input type="checkbox" value="Збирання даних"> Збирання даних</label>
-        <label><input type="checkbox" value="Валідація"> Валідація</label>
-        <label><input type="checkbox" value="Очищення даних"> Очищення даних</label>
-        <label><input type="checkbox" value="Курація та організація даних"> Курація та організація даних</label>
-        <label><input type="checkbox" value="Аналіз даних"> Аналіз даних</label>
-        <label><input type="checkbox" value="Візуалізація"> Візуалізація</label>
-        <label><input type="checkbox" value="Перевірка відтворюваності"> Перевірка відтворюваності</label>
-      </div>
+        <summary>{{ site.data.terms.data.label_uk }}</summary>
+        <div class="task-group">
+            {%- for element in site.data.terms.data.terms %}
+            <label><input type="checkbox" value="{{ element.label_uk }}">{{ element.label_uk }}</label>
+            {%- endfor %}
+        </div>
     </details>
 
     <details>
-      <summary>Написання й редагування</summary>
-      <div class="task-group">
-        <label><input type="checkbox" value="Генерування тексту"> Генерування тексту</label>
-        <label><input type="checkbox" value="Вичитування та редагування"> Вичитування та редагування</label>
-        <label><input type="checkbox" value="Резюмування тексту"> Резюмування тексту</label>
-        <label><input type="checkbox" value="Формулювання висновків"> Формулювання висновків</label>
-        <label><input type="checkbox" value="Адаптація та коригування емоційного тону"> Адаптація та коригування емоційного тону</label>
-        <label><input type="checkbox" value="Переклад"> Переклад</label>
-        <label><input type="checkbox" value="Реформатування"> Реформатування</label>
-        <label><input type="checkbox" value="Підготовка пресрелізів та матеріалів для популяризації"> Підготовка пресрелізів та матеріалів для популяризації</label>
-      </div>
+        <summary>{{ site.data.terms.writing.label_uk }}</summary>
+        <div class="task-group">
+            {%- for element in site.data.terms.writing.terms %}
+            <label><input type="checkbox" value="{{ element.label_uk }}">{{ element.label_uk }}</label>
+            {%- endfor %}
+        </div>
     </details>
 
     <details>
-      <summary>Етичний аналіз</summary>
-      <div class="task-group">
-        <label><input type="checkbox" value="Аналіз упередженості та потенційної дискримінації"> Аналіз упередженості та потенційної дискримінації</label>
-        <label><input type="checkbox" value="Аналіз етичних ризиків"> Аналіз етичних ризиків</label>
-        <label><input type="checkbox" value="Моніторинг дотримання етичних стандартів"> Моніторинг дотримання етичних стандартів</label>
-        <label><input type="checkbox" value="Моніторинг конфіденційності даних"> Моніторинг конфіденційності даних</label>
-      </div>
+        <summary>{{ site.data.terms.review.label_uk }}</summary>
+        <div class="task-group">
+            {%- for element in site.data.terms.ethics.terms %}
+            <label><input type="checkbox" value="{{ element.label_uk }}">{{ element.label_uk }}</label>
+            {%- endfor %}
+        </div>
     </details>
 
     <details>
-      <summary>Нагляд і керівництво</summary>
-      <div class="task-group">
-        <label><input type="checkbox" value="Оцінювання якості"> Оцінювання якості</label>
-        <label><input type="checkbox" value="Виявлення трендів"> Виявлення трендів</label>
-        <label><input type="checkbox" value="Визначення обмежень"> Визначення обмежень</label>
-        <label><input type="checkbox" value="Рекомендації"> Рекомендації</label>
-        <label><input type="checkbox" value="Підтримка публікації"> Підтримка публікації</label>
-      </div>
+        <summary>{{ site.data.terms.supervision.label_uk }}</summary>
+        <div class="task-group">
+            {%- for element in site.data.terms.supervision.terms %}
+            <label><input type="checkbox" value="{{ element.label_uk }}">{{ element.label_uk }}</label>
+            {%- endfor %}
+        </div>
     </details>
   </div>
 

--- a/index-uk.html
+++ b/index-uk.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="uk">
 <head>

--- a/index.html
+++ b/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/index.html
+++ b/index.html
@@ -86,91 +86,75 @@
     <h2>3. Select Delegated Tasks (from GAIDeT taxonomy)</h2>
 
     <details open>
-      <summary>Conceptualization</summary>
-      <div class="task-group">
-        <label><input type="checkbox" value="Idea generation"> Idea generation</label>
-        <label><input type="checkbox" value="Defining the research objective"> Defining the research objective</label>
-        <label><input type="checkbox" value="Formulating research questions and hypotheses"> Formulating research questions and hypotheses</label>
-        <label><input type="checkbox" value="Feasibility assessment and risk evaluation"> Feasibility assessment and risk evaluation</label>
-        <label><input type="checkbox" value="Preliminary hypothesis testing"> Preliminary hypothesis testing</label>
-      </div>
+        <summary>Conceptualization</summary>
+        <div class="task-group">
+            {%- for element in site.data.terms.conceptualization %}
+            <label><input type="checkbox" value="{{ element.label }}">{{ element.label }}</label>
+            {%- endfor %}
+        </div>
     </details>
 
     <details>
-      <summary>Literature Review</summary>
-      <div class="task-group">
-        <label><input type="checkbox" value="Literature search, systematization, and "> Literature search and systematization</label>
-         <label><input type="checkbox" value="Writing the literature review"> Writing the literature review</label>
-	<label><input type="checkbox" value="Analysis of market trends and/or patent environment"> Analysis of market trends and/or patent environment</label>
-        <label><input type="checkbox" value="Evaluation of the novelty of the research and identification of gaps"> Evaluation of the novelty of the research and identification of gaps</label>
-      </div>
+        <summary>Literature Review</summary>
+        <div class="task-group">
+            {%- for element in site.data.terms.review %}
+            <label><input type="checkbox" value="{{ element.label }}">{{ element.label }}</label>
+            {%- endfor %}
+        </div>
     </details>
 
     <details>
-      <summary>Methodology</summary>
-      <div class="task-group">
-        <label><input type="checkbox" value="Research design"> Research design</label>
-        <label><input type="checkbox" value="Development of experimental or research protocols"> Development of experimental or research protocols</label>
-        <label><input type="checkbox" value="Selection of research methods"> Selection of research methods</label>
-      </div>
+        <summary>Methodology</summary>
+        <div class="task-group">
+            {%- for element in site.data.terms.methodology %}
+            <label><input type="checkbox" value="{{ element.label }}">{{ element.label }}</label>
+            {%- endfor %}
+        </div>
     </details>
 
     <details>
-      <summary>Software Development and Automation</summary>
-      <div class="task-group">
-        <label><input type="checkbox" value="Code generation"> Code generation</label>
-        <label><input type="checkbox" value="Code optimization"> Code optimization</label>
-        <label><input type="checkbox" value="Process automation"> Process automation</label>
-        <label><input type="checkbox" value="Creation of algorithms for data analysis"> Creation of algorithms for data analysis</label>
-      </div>
+        <summary>Software Development and Automation</summary>
+        <div class="task-group">
+            {%- for element in site.data.terms.software %}
+            <label><input type="checkbox" value="{{ element.label }}">{{ element.label }}</label>
+            {%- endfor %}
+        </div>
     </details>
 
     <details>
-      <summary>Data Management</summary>
-      <div class="task-group">
-        <label><input type="checkbox" value="Data collection"> Data collection</label>
-        <label><input type="checkbox" value="Validation"> Validation</label>
-        <label><input type="checkbox" value="Data cleaning"> Data cleaning</label>
-        <label><input type="checkbox" value="Data curation and organization"> Data curation and organization</label>
-        <label><input type="checkbox" value="Data analysis"> Data analysis</label>
-        <label><input type="checkbox" value="Visualization"> Visualization</label>
-        <label><input type="checkbox" value="Reproducibility testing"> Reproducibility testing</label>
-      </div>
+        <summary>Data Management</summary>
+        <div class="task-group">
+            {%- for element in site.data.terms.data %}
+            <label><input type="checkbox" value="{{ element.label }}">{{ element.label }}</label>
+            {%- endfor %}
+        </div>
     </details>
 
     <details>
-      <summary>Writing and Editing</summary>
-      <div class="task-group">
-        <label><input type="checkbox" value="Text generation"> Text generation</label>
-        <label><input type="checkbox" value="Proofreading and editing"> Proofreading and editing</label>
-	<label><input type="checkbox" value="Summarizing text"> Summarizing text</label>
-        <label><input type="checkbox" value="Formulation of conclusions"> Formulation of conclusions</label>
-        <label><input type="checkbox" value="Adapting and adjusting emotional tone"> Adapting and adjusting emotional tone</label>
-        <label><input type="checkbox" value="Translation"> Translation</label>
-        <label><input type="checkbox" value="Reformatting"> Reformatting</label>
-        <label><input type="checkbox" value="Preparation of press releases and outreach materials"> Preparation of press releases and outreach materials</label>
-      </div>
+        <summary>Writing and Editing</summary>
+        <div class="task-group">
+            {%- for element in site.data.terms.writing %}
+            <label><input type="checkbox" value="{{ element.label }}">{{ element.label }}</label>
+            {%- endfor %}
+        </div>
     </details>
 
     <details>
-      <summary>Ethics Review</summary>
-      <div class="task-group">
-        <label><input type="checkbox" value="Bias analysis and potential discrimination assessment"> Bias analysis and potential discrimination assessment</label>
-        <label><input type="checkbox" value="Ethical risk analysis"> Ethical risk analysis</label>
-        <label><input type="checkbox" value="Monitoring compliance with ethical standards"> Monitoring compliance with ethical standards</label>
-        <label><input type="checkbox" value="Data confidentiality monitoring"> Data confidentiality monitoring</label>
-      </div>
+        <summary>Ethics Review</summary>
+        <div class="task-group">
+            {%- for element in site.data.terms.ethics %}
+            <label><input type="checkbox" value="{{ element.label }}">{{ element.label }}</label>
+            {%- endfor %}
+        </div>
     </details>
 
     <details>
-      <summary>Supervision</summary>
-      <div class="task-group">
-        <label><input type="checkbox" value="Quality assessment"> Quality assessment</label>
-        <label><input type="checkbox" value="Trend identification"> Trend identification</label>
-        <label><input type="checkbox" value="Identification of limitations"> Identification of limitations</label>
-        <label><input type="checkbox" value="Recommendations"> Recommendations</label>
-        <label><input type="checkbox" value="Publication support"> Publication support</label>
-      </div>
+        <summary>Supervision</summary>
+        <div class="task-group">
+            {%- for element in site.data.terms.ethics %}
+            <label><input type="checkbox" value="{{ element.label }}">{{ element.label }}</label>
+            {%- endfor %}
+        </div>
     </details>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -88,72 +88,72 @@
     <h2>3. Select Delegated Tasks (from GAIDeT taxonomy)</h2>
 
     <details open>
-        <summary>Conceptualization</summary>
+        <summary>{{ site.data.terms.conceptualization.label }}</summary>
         <div class="task-group">
-            {%- for element in site.data.terms.conceptualization %}
+            {%- for element in site.data.terms.conceptualization.terms %}
             <label><input type="checkbox" value="{{ element.label }}">{{ element.label }}</label>
             {%- endfor %}
         </div>
     </details>
 
     <details>
-        <summary>Literature Review</summary>
+        <summary>{{ site.data.terms.review.label }}</summary>
         <div class="task-group">
-            {%- for element in site.data.terms.review %}
+            {%- for element in site.data.terms.review.terms %}
             <label><input type="checkbox" value="{{ element.label }}">{{ element.label }}</label>
             {%- endfor %}
         </div>
     </details>
 
     <details>
-        <summary>Methodology</summary>
+        <summary>{{ site.data.terms.methodology.label }}</summary>
         <div class="task-group">
-            {%- for element in site.data.terms.methodology %}
+            {%- for element in site.data.terms.methodology.terms %}
             <label><input type="checkbox" value="{{ element.label }}">{{ element.label }}</label>
             {%- endfor %}
         </div>
     </details>
 
     <details>
-        <summary>Software Development and Automation</summary>
+        <summary>{{ site.data.terms.software.label }}</summary>
         <div class="task-group">
-            {%- for element in site.data.terms.software %}
+            {%- for element in site.data.terms.software.terms %}
             <label><input type="checkbox" value="{{ element.label }}">{{ element.label }}</label>
             {%- endfor %}
         </div>
     </details>
 
     <details>
-        <summary>Data Management</summary>
+        <summary>{{ site.data.terms.data.label }}</summary>
         <div class="task-group">
-            {%- for element in site.data.terms.data %}
+            {%- for element in site.data.terms.data.terms %}
             <label><input type="checkbox" value="{{ element.label }}">{{ element.label }}</label>
             {%- endfor %}
         </div>
     </details>
 
     <details>
-        <summary>Writing and Editing</summary>
+        <summary>{{ site.data.terms.writing.label }}</summary>
         <div class="task-group">
-            {%- for element in site.data.terms.writing %}
+            {%- for element in site.data.terms.writing.terms %}
             <label><input type="checkbox" value="{{ element.label }}">{{ element.label }}</label>
             {%- endfor %}
         </div>
     </details>
 
     <details>
-        <summary>Ethics Review</summary>
+        <summary>{{ site.data.terms.review.label }}</summary>
         <div class="task-group">
-            {%- for element in site.data.terms.ethics %}
+            {%- for element in site.data.terms.ethics.terms %}
             <label><input type="checkbox" value="{{ element.label }}">{{ element.label }}</label>
             {%- endfor %}
         </div>
     </details>
 
     <details>
-        <summary>Supervision</summary>
+        <summary>{{ site.data.terms.supervision.label }}</summary>
         <div class="task-group">
-            {%- for element in site.data.terms.ethics %}
+            {%- for element in site.data.terms.supervision.terms %}
             <label><input type="checkbox" value="{{ element.label }}">{{ element.label }}</label>
             {%- endfor %}
         </div>

--- a/justfile
+++ b/justfile
@@ -1,0 +1,6 @@
+serve:
+  # Note that the 4.2.0 tag is important - 4.2.2 (latest, released ~2022) does not work.
+  docker run --rm --volume="$PWD:/srv/jekyll" -p 4000:4000 -it jekyll/jekyll:4.2.0 jekyll serve
+
+format:
+  npx prettier --prose-wrap always --check "**/*.html" --write


### PR DESCRIPTION
This pull request takes the checkboxes out of both the english and ukranian HTML files and puts them in a YAML configuration. It then configures the repository to use Jekyll (built in to github) to generate the HTML pages from templates, based on that data.

This is a first step towards making the taxonomy reusable. Next step (future PR) will be to map back to credit taxonomy terms, assign stable identifiers to each, and create proper ontology artifact files.